### PR TITLE
Adding support for building packages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ go run ./cli/lifecycled/*.go --queue simulate --handler ./handler.sh --instancei
 ```
 
 ## Releasing
+### Building binary
+```bash
+docker build --tag lifecycled-builder release/
+docker run --rm -v "$PWD":/go/src/github.com/lox/lifecycled lifecycled-builder build.sh
+ls -al builds/
+```
+### Building package
 
 ```bash
-glide install
 docker build --tag lifecycled-builder release/
-docker run --rm -v "$PWD":/go/src/github.com/lox/lifecycled lifecycled-builder
-ls -al builds/
+docker run -v "$PWD":/go/src/github.com/lox/lifecycled -v "$PWD/output":/go/src/output -e LIFECYCLE_QUEUE=yourqueue -e AWS_REGION=yourregion lifecycled-public pkg-builder.sh $VERSION
+ls -al output/
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ ls -al builds/
 
 ```bash
 docker build --tag lifecycled-builder release/
-docker run -v "$PWD":/go/src/github.com/lox/lifecycled -v "$PWD/output":/go/src/output -e LIFECYCLE_QUEUE=yourqueue -e AWS_REGION=yourregion lifecycled-public pkg-builder.sh $VERSION
+docker run --rm -v "$PWD/output":/go/src/output -v "$PWD":/go/src/github.com/lox/lifecycled -e LIFECYCLE_QUEUE=yourqueue -e AWS_REGION=yourregion -e PKG_VERSION=1.0.0 lifecycled-builder pkg-builder.sh
 ls -al output/
 ```

--- a/init/lifecycled
+++ b/init/lifecycled
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# lifecycled        Manage the consul agent
+#
+# chkconfig:   2345 95 95
+# description: Lifecycle is a tool for managing aws workflow hooks
+# processname: lifecycled
+# pidfile: /var/run/lifecycled.pid
+
+### BEGIN INIT INFO
+# Provides:       lifecycled
+# Required-Start: $local_fs $network
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start: 2 3 4 5
+# Default-Stop:  0 1 6
+# Short-Description: Manage the lifecycled agent
+# Description: Lifecycle is a tool for managing aws workflow hooks
+### END INIT INFO
+
+# source function library
+. /etc/rc.d/init.d/functions
+
+prog="lifecycled"
+exec="/usr/local/bin/$prog"
+pidfile="/var/run/$prog.pid"
+lockfile="/var/lock/subsys/$prog"
+logfile="/var/log/$prog"
+# Use these in future iterations 
+#conffile="/etc/lifecycled.conf"
+#confdir="/etc/lifecycled.d"
+
+# pull in sysconfig settings
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+export INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id --silent)
+export AWS_REGION=us-west-2
+
+start() {
+    [ -x $exec ] || exit 5
+
+    umask 077
+
+    touch $logfile $pidfile
+
+    echo -n $"Starting $prog: "
+    echo *******Service Start******* >> $logfile
+    $exec --queue $LIFECYCLE_QUEUE --handler /etc/lifecycled-runner.sh --instanceid $INSTANCE_ID  >> $logfile 2>&1 &
+    PID=$!
+    RETVAL=$?
+    echo
+
+    [ $RETVAL -eq 0 ] && touch $lockfile && echo $! > $pidfile
+
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Shutting down $prog: "
+    killproc -p $pidfile $exec
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f $lockfile
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p $pidfile $exec -HUP
+    echo
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    status -p "$pidfile" -l $prog $exec
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        $1
+        ;;
+    stop)
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart}"
+        exit 2
+esac
+
+exit $?

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,31 @@
 FROM golang:1.6
-ADD build.sh /usr/bin/build.sh
+
+## Used to build packages
+RUN apt-get update
+RUN apt-get install ruby2.1 -y
+RUN apt-get install rubygems -y
+RUN apt-get install ruby2.1-dev -y
+RUN apt-get install rpm -y
+
+## SETUP GLIDE
+WORKDIR /
+RUN wget https://github.com/Masterminds/glide/releases/download/v0.12.2/glide-v0.12.2-linux-386.tar.gz
+RUN tar xvf glide-v0.12.2-linux-386.tar.gz
+RUN cp linux-386/glide /usr/bin/glide
+
 WORKDIR /go/src/github.com/lox/lifecycled
-ENTRYPOINT /usr/bin/build.sh
+
+RUN gem install fpm --no-ri --no-rdoc
+
+WORKDIR /go/src
+RUN mkdir builds
+RUN mkdir output
+RUN mkdir etc
+RUN mkdir etc/init.d
+RUN mkdir etc/sysconfig
+
+ADD build.sh /usr/bin/build.sh
+ADD pkg-builder.sh /usr/bin/pkg-builder.sh
+WORKDIR /go/src/github.com/lox/lifecycled
+
+#ENTRYPOINT /usr/bin/build.sh

--- a/release/build.sh
+++ b/release/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh -ex
+
+/usr/bin/glide install
 bin="builds/lifecycled-linux-$(uname -m)"
 mkdir -p builds/
 CGO_ENABLED=0 go build -ldflags "-s" -a -installsuffix cgo -o $bin ./cli/lifecycled

--- a/release/pkg-builder.sh
+++ b/release/pkg-builder.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+VERSION=$1
+
+/usr/bin/build.sh
+cd /go/src
+cp /go/src/github.com/lox/lifecycled/builds/lifecycled-linux-$(uname -m) /go/src/builds/lifecycled
+cp /go/src/github.com/lox/lifecycled/init/lifecycled /go/src/etc/init.d/
+cp /go/src/github.com/lox/lifecycled/handler.sh /go/src/etc/lifecycled-runner.sh
+
+echo export LIFECYCLE_QUEUE=$LIFECYCLE_QUEUE > /go/src/etc/sysconfig/lifecycled
+echo export AWS_REGION=$AWS_REGION >> /go/src/etc/sysconfig/lifecycled
+
+chmod +x ./etc/sysconfig/lifecycled
+fpm --verbose  --rpm-os linux -s dir -t deb \
+    -n lifecycled  -v ${VERSION} \
+    -p /go/src/output/NAME_FULLVERSION_ARCH.TYPE \
+    --url=https://github.com/lox/lifecycled \
+    --vendor=Lox \
+    --description "AWS Lifecycle Management" \
+    ./builds/lifecycled=/usr/local/bin/lifecycled \
+    ./etc/init.d/=/etc/init.d/ \
+    ./etc/sysconfig/=/etc/sysconfig/ \
+    ./etc/lifecycled-runner.sh=/etc/lifecycled-runner.sh
+
+
+fpm --verbose --rpm-os linux -s dir -t rpm \
+    -n lifecycled  -v ${VERSION} \
+    -p /go/src/output/NAME_FULLVERSION_ARCH.TYPE \
+    --url=https://github.com/lox/lifecycled \
+    --vendor=Lox \
+    --description "AWS Lifecycle Management" \
+    ./builds/lifecycled=/usr/local/bin/lifecycled \
+    ./etc/init.d/=/etc/init.d/ \
+    ./etc/sysconfig/=/etc/sysconfig/ \
+    ./etc/lifecycled-runner.sh=/etc/lifecycled-runner.sh
+

--- a/release/pkg-builder.sh
+++ b/release/pkg-builder.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-VERSION=$1
 
 /usr/bin/build.sh
 cd /go/src
@@ -12,7 +11,7 @@ echo export AWS_REGION=$AWS_REGION >> /go/src/etc/sysconfig/lifecycled
 
 chmod +x ./etc/sysconfig/lifecycled
 fpm --verbose  --rpm-os linux -s dir -t deb \
-    -n lifecycled  -v ${VERSION} \
+    -n lifecycled  -v ${PKG_VERSION} \
     -p /go/src/output/NAME_FULLVERSION_ARCH.TYPE \
     --url=https://github.com/lox/lifecycled \
     --vendor=Lox \
@@ -24,7 +23,7 @@ fpm --verbose  --rpm-os linux -s dir -t deb \
 
 
 fpm --verbose --rpm-os linux -s dir -t rpm \
-    -n lifecycled  -v ${VERSION} \
+    -n lifecycled  -v ${PKG_VERSION} \
     -p /go/src/output/NAME_FULLVERSION_ARCH.TYPE \
     --url=https://github.com/lox/lifecycled \
     --vendor=Lox \


### PR DESCRIPTION
I've updated the Dockerfile to include ruby and the fpm gem. This will allow the optional building a rpm/deb package. You now pass into the dockerfile either build.sh for binary building, or pkg-builder.sh for building a package. 